### PR TITLE
Fixed docker build error

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@ FROM node:latest AS build-js
 
 RUN npm install gulp gulp-cli -g
 
-RUN apt update && apt install git
+RUN apt update && apt install -y git
 WORKDIR /build
 RUN git clone https://github.com/gophish/gophish .
 RUN npm install --only=dev


### PR DESCRIPTION
When following the instructions to install sneaky gophish, 
```
git clone https://github.com/puzzlepeaches/sneaky_gophish && \
  cd sneaky_gophish && \
  docker build -t sneaky_gophish .
```
I was getting an error in the docker build command, in this part specifically
```
RUN apt update && apt install git
```
Adding the `-y` after install fixes it.